### PR TITLE
Issue #8 Add MHIST bash script

### DIFF
--- a/tools/mhist/mhist_prepare.sh
+++ b/tools/mhist/mhist_prepare.sh
@@ -1,0 +1,42 @@
+# mhist_prepare.sh
+# Prepares the MHIST dataset for EVA.
+# Expects the user to have manually downloaded images.zip and annotations.csv into ./data/mhist
+
+#!/usr/bin/env bash
+set -e # Exit on error
+
+# Path to MHIST dataset
+DATA_DIR="./data/mhist"
+
+# Check if the folder exists
+if [ ! -d "$DATA_DIR" ]; then
+  echo "ERROR: $DATA_DIR does not exist. Please create and place the files there."
+  exit 1
+fi
+
+# Create images folder if it doesn't exist
+mkdir -p "$DATA_DIR/images"
+
+# Unzip images.zip into images folder
+if [ -f "$DATA_DIR/images.zip" ]; then
+  echo "[INFO] Unzipping images.zip..."
+  unzip -o -j "$DATA_DIR/images.zip" -d "$DATA_DIR/images"
+  echo "[INFO] Unzipping completed."
+else
+  echo "WARNING: images.zip not found in $DATA_DIR. Skipping unzip."
+fi
+
+# Delete images.zip after extraction
+if [ -f "$DATA_DIR/images.zip" ]; then
+  echo "[INFO] Deleting images.zip..."
+  rm "$DATA_DIR/images.zip"
+fi
+
+# Check if annotations.csv exists
+if [ -f "$DATA_DIR/annotations.csv" ]; then
+  echo "[INFO] annotations.csv found."
+else
+  echo "WARNING: annotations.csv not found in $DATA_DIR. Please make sure it is placed there."
+fi
+
+exit 0


### PR DESCRIPTION
Adds the bash script `mhist_prepare.sh` (in `tools/mhist`) to prepare the MHIST dataset for EVA. Before running the script, expects the user to manually download and place `images.zip` and `annotations.csv` into `./data/mhist` folder.

Run: `./tools/mhist/mhist_prepare.sh`
- Unzips `images.zip` into the images folder.
- Deletes `images.zip` once unzipping is completed.
- Checks for `annotations.csv` and warns if missing.

<img width="391" height="141" alt="MHIST_bash_image" src="https://github.com/user-attachments/assets/aef0db9d-3eb0-44e7-a7e4-cb07eed7ccc2" />

Ran `eva predict_fit --config configs/vision/pathology/offline/classification/mhist.yaml`  

<img width="761" height="240" alt="Screenshot from 2025-09-08 18-17-30" src="https://github.com/user-attachments/assets/82610d13-8000-4147-89ea-7510efa65ec1" />

