### PR TITLE
Download CONSEP

### DIFF
--- a/src/eva/vision/data/datasets/segmentation/consep.py
+++ b/src/eva/vision/data/datasets/segmentation/consep.py
@@ -108,7 +108,7 @@ class CoNSeP(wsi.MultiWsiDataset, vision.VisionDataset[tv_tensors.Image, tv_tens
             n_classes=5,
             first_and_last_labels=((self.classes[0], self.classes[-1])),
         )
-        n_expected = self._expected_dataset_lengths[None]
+        n_expected = self._expected_dataset_lengths[self._split]
         if len(self._file_paths) != n_expected:
             raise ValueError(
                 f"Expected {n_expected} images, found {len(self._file_paths)} in {self._root}."

--- a/tools/consep/download_consep.sh
+++ b/tools/consep/download_consep.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Usage: ./download_consep.sh /path/to/data
+# Requires ACCESS_KEY_ID and SECRET_ACCESS_KEY in environment variables
+
+set -e
+
+# Load .env if present in the script’s folder
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -f "$SCRIPT_DIR/.env" ]]; then
+  export $(grep -v '^#' "$SCRIPT_DIR/.env" | xargs)
+fi
+
+ROOT=${1:-"./data"}
+DEST="$ROOT/consep"
+
+echo "[INFO] Preparing CoNSeP dataset under $DEST"
+mkdir -p "$DEST"
+
+# Ensure openxlab is installed
+pip show openxlab >/dev/null 2>&1 || pip install -U openxlab
+
+# Login non-interactively
+if [[ -z "$ACCESS_KEY_ID" || -z "$SECRET_ACCESS_KEY" ]]; then
+  echo "[ERROR] Please export ACCESS_KEY_ID and SECRET_ACCESS_KEY before running."
+  exit 1
+fi
+echo "[INFO] Logging into OpenXLab..."
+openxlab login --ak "$ACCESS_KEY_ID" --sk "$SECRET_ACCESS_KEY"
+
+# Download dataset
+echo "[INFO] Downloading CoNSeP dataset..."
+openxlab dataset get --dataset-repo OpenDataLab/CoNSeP --target-path "$DEST"
+
+# Unzip consep.zip into $DEST/tmp_extract
+ZIP_PATH="$DEST/OpenDataLab___CoNSeP/raw/consep.zip"
+if [[ ! -f "$ZIP_PATH" ]]; then
+  echo "[ERROR] Expected $ZIP_PATH not found."
+  exit 1
+fi
+
+TMP_EXTRACT="$DEST/tmp_extract"
+mkdir -p "$TMP_EXTRACT"
+echo "[INFO] Extracting $ZIP_PATH..."
+unzip -q "$ZIP_PATH" -d "$TMP_EXTRACT"
+
+# Move Test and Train directly under $DEST
+if [[ -d "$TMP_EXTRACT/CoNSEP" ]]; then
+  mv "$TMP_EXTRACT/CoNSEP/Test" "$DEST/"
+  mv "$TMP_EXTRACT/CoNSEP/Train" "$DEST/"
+else
+  echo "[ERROR] Unexpected structure inside zip."
+  exit 1
+fi
+
+# Move metafile.yaml and README.md to $DEST
+echo "[INFO] Organizing files..."
+mv "$DEST/OpenDataLab___CoNSeP/metafile.yaml" "$DEST/"
+mv "$DEST/OpenDataLab___CoNSeP/README.md" "$DEST/"
+
+# Cleanup
+rm -rf "$DEST/OpenDataLab___CoNSeP"
+rm -rf "$TMP_EXTRACT"
+
+echo "[INFO] Done. Final structure:"
+ls -R "$DEST"


### PR DESCRIPTION
The download script require two keys which can be get by sign up to [OpenDataLab](https://opendatalab.com/OpenDataLab/CoNSeP/tree/main/raw).

I also change the expected dataset lengths validation logic (just one indexing in the code) to validate length of train to be 27 and val to be 14. Previously it doesn't account for the split (train/test) and use the 41 (with None as key) in the dictionary _expected_dataset_lengths. 

 #4 
 
 I run `eva predict_fit --config "./configs/vision/pathology/offline/segmentation/consep.yaml"` 
 
<img width="1144" height="520" alt="Screenshot 2025-09-06 at 3 01 40 PM" src="https://github.com/user-attachments/assets/3463cc32-32ec-49c9-91a9-8cfd3bcb9618" />
