### PR TITLE
add script for downloading BCSS dataset (resolves #5)

### DIFF
--- a/tools/download_bcss.sh
+++ b/tools/download_bcss.sh
@@ -1,0 +1,3 @@
+python3 -m pip install -U "huggingface_hub[cli]"
+mkdir -p ../data
+hf download nabil-m/bcss --repo-type dataset --local-dir ../data/bcss


### PR DESCRIPTION
The Breast Cancer Semantic Segmentation (BCSS) dataset is licensed under a [CC0 1.0 Universal (CC0 1.0) license](https://creativecommons.org/publicdomain/zero/1.0/), allowing redistribution.  Creating a mirror for it on Hugging Face (HF) and downloading from there allows for a simple, 3-line bash script. 

## Usage
`chmod +x tools/download_bcss.sh`
`bash tools/download_bcss.sh`
`N_DATA_WORKERS=1 eva predict_fit --config configs/vision/pathology/offline/segmentation/bcss.yaml`

Note: For local evaluation, I specified that N_DATA_WORKERS should be 1 when calling `eva predict_fit` (as opposed to the default of 4 in the .yaml file), and let the process run overnight, to get the following results.

## Results
<img width="1426" height="776" alt="Screenshot 2025-09-27 062536" src="https://github.com/user-attachments/assets/d3aed309-3dfb-4bf4-b569-e50e217d61dd" />


